### PR TITLE
Add Qt6 desktop installer with repair/update support

### DIFF
--- a/collector/package.json
+++ b/collector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anything-llm-document-collector",
-  "version": "1.8.5",
+  "version": "1.9.0",
   "description": "Document collector server endpoints",
   "main": "index.js",
   "author": "Timothy Carambat (Mintplex Labs)",

--- a/extras/qt-installer/.gitignore
+++ b/extras/qt-installer/.gitignore
@@ -1,0 +1,18 @@
+# Build artefacts
+build/
+CMakeFiles/
+CMakeCache.txt
+*.user
+*.pro.user
+Makefile
+*.obj
+*.o
+*.pdb
+*.ilk
+*.ninja
+*.qrc.depends
+compile_commands.json
+*.dll
+*.exe
+*.app
+*.dSYM

--- a/extras/qt-installer/CMakeLists.txt
+++ b/extras/qt-installer/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.16)
+project(AnythingLLMInstaller VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Widgets Concurrent)
+
+if (COMMAND qt_standard_project_setup)
+    qt_standard_project_setup()
+endif()
+
+set(INSTALLER_SOURCES
+    src/main.cpp
+    src/installerwindow.cpp
+    src/installerlogic.cpp
+)
+
+set(INSTALLER_HEADERS
+    src/installerwindow.h
+    src/installerlogic.h
+)
+
+qt_add_executable(anything-llm-installer
+    ${INSTALLER_SOURCES}
+    ${INSTALLER_HEADERS}
+    resources/installer.qrc
+)
+
+if (NOT DEFINED APP_VERSION)
+    set(APP_VERSION "1.9.0")
+endif()
+
+target_compile_definitions(anything-llm-installer PRIVATE APP_VERSION="${APP_VERSION}")
+
+target_include_directories(anything-llm-installer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+target_link_libraries(anything-llm-installer PRIVATE Qt6::Widgets Qt6::Concurrent)
+
+install(TARGETS anything-llm-installer
+        RUNTIME DESTINATION bin
+        BUNDLE DESTINATION .
+        LIBRARY DESTINATION lib)

--- a/extras/qt-installer/README.md
+++ b/extras/qt-installer/README.md
@@ -1,0 +1,45 @@
+# Instalador gráfico AnythingLLM (Qt 6)
+
+Este diretório contém um instalador gráfico desenvolvido com Qt 6 para facilitar a distribuição do AnythingLLM.
+
+## Funcionalidades
+
+* **Verificação inteligente da instalação**: identifica automaticamente instalações prévias, informando a versão encontrada e oferecendo ações de atualização ou reparo quando necessário.
+* **Instalação guiada**: permite escolher o diretório de destino e acompanha o progresso da cópia dos arquivos da aplicação.
+* **Criação de atalhos**: gera atalhos para a aplicação tanto na área de trabalho quanto no menu Iniciar/aplicativos (quando suportado pelo sistema operacional).
+
+## Estrutura esperada
+
+O instalador presume que os artefatos da aplicação estejam disponíveis em um diretório `payload` localizado ao lado do executável gerado. Durante a instalação todos os arquivos são copiados recursivamente desse diretório para o destino escolhido.
+
+```
+qt-installer/
+├── build/
+├── payload/
+│   └── ... arquivos da distribuição AnythingLLM ...
+└── anything-llm-installer (binário gerado)
+```
+
+Ao final da instalação é criado (ou atualizado) o arquivo `installer-state.json` na pasta de configuração do usuário contendo o caminho e a versão instalada, permitindo que futuras execuções do instalador detectem o estado atual.
+
+## Como compilar
+
+1. Instale o Qt 6 (módulos *Widgets* e *Concurrent*) e o CMake 3.16 ou superior.
+2. Gere um diretório de build e execute o CMake apontando para esta pasta:
+
+   ```bash
+   cmake -S extras/qt-installer -B extras/qt-installer/build -DAPP_VERSION="$(node -p "require('./package.json').version")"
+   cmake --build extras/qt-installer/build --target anything-llm-installer
+   ```
+
+3. Copie os artefatos da aplicação para `extras/qt-installer/build/payload` antes de executar o instalador.
+
+## Atalhos criados
+
+* **Windows**: arquivos `.lnk` gerados via PowerShell na área de trabalho e no menu Iniciar.
+* **Linux**: arquivos `.desktop` colocados na área de trabalho do usuário e em `~/.local/share/applications` (ou diretório equivalente retornado por `QStandardPaths`).
+* **macOS**: criação de alias simbólico na área de trabalho.
+
+## Personalização
+
+As ações de instalação são encapsuladas em `InstallerLogic`, permitindo ajustes específicos, como validação de arquivos copiados, suporte a backups ou etapas adicionais pós-instalação.

--- a/extras/qt-installer/resources/installer.qrc
+++ b/extras/qt-installer/resources/installer.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file alias="icons/app-icon.png">../../images/wordmark.png</file>
+    </qresource>
+</RCC>

--- a/extras/qt-installer/src/installerlogic.cpp
+++ b/extras/qt-installer/src/installerlogic.cpp
@@ -1,0 +1,506 @@
+#include "installerlogic.h"
+
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QDir>
+#include <QDirIterator>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLatin1String>
+#include <QtGlobal>
+#include <QProcess>
+#include <QStandardPaths>
+#include <QTemporaryFile>
+#include <QtConcurrent>
+
+#include <algorithm>
+
+namespace {
+QString sanitizePath(QString path) {
+    QDir dir(path);
+    return dir.absolutePath();
+}
+}
+
+InstallerLogic::InstallerLogic(QObject *parent)
+    : QObject(parent),
+      m_availableVersion(QStringLiteral(APP_VERSION)) {
+    qRegisterMetaType<InstallerLogic::InstallationStatus>("InstallerLogic::InstallationStatus");
+    qRegisterMetaType<InstallerLogic::InstallResult>("InstallerLogic::InstallResult");
+}
+
+void InstallerLogic::startDetection() {
+    QtConcurrent::run([this]() {
+        InstallationStatus status = detectInstallation();
+        emit detectionFinished(status);
+    });
+}
+
+void InstallerLogic::startInstallation(const QString &targetPath,
+                                       InstallAction action,
+                                       bool createDesktopShortcut,
+                                       bool createMenuShortcut) {
+    const QString sanitizedPath = sanitizePath(targetPath);
+    QtConcurrent::run([this, sanitizedPath, action, createDesktopShortcut, createMenuShortcut]() {
+        InstallResult result = performInstallation(sanitizedPath, action, createDesktopShortcut, createMenuShortcut);
+        emit installationFinished(result);
+    });
+}
+
+QString InstallerLogic::defaultInstallPath() const {
+#ifdef Q_OS_WIN
+    QString base = QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);
+    if (base.isEmpty()) {
+        base = QDir::home().filePath("AppData/Local/Programs");
+    }
+    return QDir(base).filePath("AnythingLLM");
+#elif defined(Q_OS_MACOS)
+    return QStringLiteral("/Applications/AnythingLLM");
+#else
+    QString base = QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);
+    if (base.isEmpty()) {
+        base = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/Aplicativos";
+    }
+    return QDir(base).filePath("AnythingLLM");
+#endif
+}
+
+QString InstallerLogic::availableVersion() const {
+    return m_availableVersion;
+}
+
+InstallerLogic::InstallationStatus InstallerLogic::detectInstallation() const {
+    InstallationStatus status;
+    status.availableVersion = m_availableVersion;
+    status.installPath = defaultInstallPath();
+
+    QFile stateFile(installerStateFilePath());
+    if (stateFile.exists() && stateFile.open(QIODevice::ReadOnly)) {
+        const QJsonDocument doc = QJsonDocument::fromJson(stateFile.readAll());
+        const QJsonObject obj = doc.object();
+        status.installPath = obj.value(QStringLiteral("path")).toString(status.installPath);
+        status.installedVersion = obj.value(QStringLiteral("version")).toString();
+        stateFile.close();
+    }
+
+    if (!status.installPath.isEmpty()) {
+        status.installPath = sanitizePath(status.installPath);
+    }
+
+    if (!status.installedVersion.isEmpty()) {
+        status.installed = true;
+        QDir installDir(status.installPath);
+        const bool pathExists = installDir.exists();
+        status.repairAvailable = true;
+        if (!pathExists) {
+            status.recommendedAction = InstallAction::RepairExisting;
+        } else {
+            const int cmp = compareVersions(status.installedVersion, status.availableVersion);
+            status.updateAvailable = cmp < 0;
+            status.recommendedAction = status.updateAvailable ? InstallAction::UpdateExisting : InstallAction::RepairExisting;
+        }
+    } else {
+        status.installed = false;
+        status.recommendedAction = InstallAction::FreshInstall;
+    }
+
+    if (status.installPath.isEmpty()) {
+        status.installPath = defaultInstallPath();
+    }
+
+    return status;
+}
+
+InstallerLogic::InstallResult InstallerLogic::performInstallation(const QString &targetPath,
+                                                                  InstallAction action,
+                                                                  bool createDesktopShortcut,
+                                                                  bool createMenuShortcut) {
+    InstallResult result;
+    QString error;
+
+    emit installationProgress(tr("Preparando instalação em %1").arg(targetPath));
+
+    if (!ensureTargetDirectory(targetPath, error, action)) {
+        result.message = error;
+        return result;
+    }
+
+    if (!copyPayload(targetPath, error)) {
+        result.message = error;
+        return result;
+    }
+
+    if (!saveInstallerState(targetPath)) {
+        result.message = tr("Não foi possível salvar o estado da instalação.");
+        return result;
+    }
+
+    QString shortcutError;
+    const bool shortcutsCreated = createShortcuts(targetPath, createDesktopShortcut, createMenuShortcut, shortcutError);
+    if (!shortcutsCreated && !shortcutError.isEmpty()) {
+        emit installationProgress(shortcutError);
+    }
+
+    emit installationStep(100);
+
+    result.success = true;
+    switch (action) {
+    case InstallAction::FreshInstall:
+        result.message = tr("Instalação concluída com sucesso.");
+        break;
+    case InstallAction::UpdateExisting:
+        result.message = tr("Atualização concluída com sucesso.");
+        break;
+    case InstallAction::RepairExisting:
+        result.message = tr("Reparo concluído com sucesso.");
+        break;
+    }
+
+    if (!shortcutsCreated) {
+        result.message += QLatin1Char('\n') + tr("Alguns atalhos não puderam ser criados. Consulte o log para mais detalhes.");
+    }
+
+    return result;
+}
+
+QString InstallerLogic::installerStateFilePath() const {
+    QString base = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+    if (base.isEmpty()) {
+        base = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    }
+    QDir dir(base);
+    dir.mkpath(QStringLiteral("anything-llm"));
+    return dir.filePath(QStringLiteral("anything-llm/installer-state.json"));
+}
+
+bool InstallerLogic::saveInstallerState(const QString &path) const {
+    QFile stateFile(installerStateFilePath());
+    QDir().mkpath(QFileInfo(stateFile).path());
+    if (!stateFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        return false;
+    }
+
+    QJsonObject obj;
+    obj.insert(QStringLiteral("path"), path);
+    obj.insert(QStringLiteral("version"), m_availableVersion);
+    obj.insert(QStringLiteral("modified"), QDateTime::currentDateTimeUtc().toString(Qt::ISODate));
+
+    const QJsonDocument doc(obj);
+    const qint64 written = stateFile.write(doc.toJson(QJsonDocument::Indented));
+    stateFile.close();
+    return written > 0;
+}
+
+QString InstallerLogic::payloadDirectory() const {
+    return QDir(QCoreApplication::applicationDirPath()).filePath(QStringLiteral("payload"));
+}
+
+bool InstallerLogic::ensureTargetDirectory(const QString &path, QString &error, InstallAction action) const {
+    QDir targetDir(path);
+    if (!targetDir.exists()) {
+        if (!QDir().mkpath(path)) {
+            error = tr("Não foi possível criar o diretório de instalação: %1").arg(path);
+            return false;
+        }
+    }
+
+    if (action == InstallAction::FreshInstall) {
+        return true;
+    }
+
+    // Para atualização ou reparo garantimos que o diretório seja gravável
+    QFileInfo info(path);
+    if (!info.isWritable()) {
+        error = tr("Sem permissão de escrita em %1").arg(path);
+        return false;
+    }
+
+    return true;
+}
+
+bool InstallerLogic::copyPayload(const QString &targetPath, QString &error) {
+    const QString source = payloadDirectory();
+    QDir sourceDir(source);
+    if (!sourceDir.exists()) {
+        error = tr("Pacote de instalação ausente em %1").arg(source);
+        return false;
+    }
+
+    emit installationProgress(tr("Copiando arquivos da aplicação..."));
+
+    m_totalFiles = countPayloadFiles(source);
+    m_copiedFiles = 0;
+    if (!copyDirectoryRecursively(source, targetPath, error)) {
+        return false;
+    }
+
+    if (m_totalFiles == 0) {
+        emit installationStep(100);
+    }
+
+    return true;
+}
+
+bool InstallerLogic::copyDirectoryRecursively(const QString &source, const QString &destination, QString &error) {
+    QDir sourceDir(source);
+    QDirIterator it(source, QDir::NoDotAndDotDot | QDir::AllEntries, QDirIterator::Subdirectories);
+
+    while (it.hasNext()) {
+        it.next();
+        const QFileInfo info = it.fileInfo();
+        const QString relativePath = sourceDir.relativeFilePath(info.absoluteFilePath());
+        const QString target = QDir(destination).filePath(relativePath);
+
+        if (info.isDir()) {
+            if (!QDir().mkpath(target)) {
+                error = tr("Não foi possível criar a pasta %1").arg(target);
+                return false;
+            }
+        } else {
+            const QString targetDir = QFileInfo(target).path();
+            if (!QDir().mkpath(targetDir)) {
+                error = tr("Não foi possível criar a pasta %1").arg(targetDir);
+                return false;
+            }
+            if (QFile::exists(target)) {
+                QFile::remove(target);
+            }
+            if (!QFile::copy(info.absoluteFilePath(), target)) {
+                error = tr("Falha ao copiar %1").arg(relativePath);
+                return false;
+            }
+            ++m_copiedFiles;
+            if (m_totalFiles > 0) {
+                const int percent = static_cast<int>((static_cast<double>(m_copiedFiles) / static_cast<double>(m_totalFiles)) * 100.0);
+                emit installationStep(qBound(0, percent, 100));
+            }
+            emit installationProgress(tr("Copiado %1").arg(relativePath));
+        }
+    }
+
+    return true;
+}
+
+qint64 InstallerLogic::countPayloadFiles(const QString &source) const {
+    qint64 count = 0;
+    QDirIterator it(source, QDir::Files, QDirIterator::Subdirectories);
+    while (it.hasNext()) {
+        it.next();
+        ++count;
+    }
+    return count;
+}
+
+int InstallerLogic::compareVersions(const QString &left, const QString &right) const {
+    const QStringList leftParts = left.split('.');
+    const QStringList rightParts = right.split('.');
+    const int maxParts = std::max(leftParts.size(), rightParts.size());
+
+    for (int i = 0; i < maxParts; ++i) {
+        const int leftValue = i < leftParts.size() ? leftParts.at(i).toInt() : 0;
+        const int rightValue = i < rightParts.size() ? rightParts.at(i).toInt() : 0;
+        if (leftValue < rightValue) {
+            return -1;
+        }
+        if (leftValue > rightValue) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+QString InstallerLogic::executablePathForShortcuts(const QString &installDir) const {
+#ifdef Q_OS_MACOS
+    return QDir(installDir).filePath(QStringLiteral("AnythingLLM.app"));
+#elif defined(Q_OS_WIN)
+    return QDir(installDir).filePath(QStringLiteral("anything-llm.exe"));
+#else
+    return QDir(installDir).filePath(QStringLiteral("anything-llm"));
+#endif
+}
+
+bool InstallerLogic::createShortcuts(const QString &targetPath, bool desktop, bool menu, QString &error) const {
+    if (!desktop && !menu) {
+        return true;
+    }
+
+    const QString executable = executablePathForShortcuts(targetPath);
+
+    if (desktop && !createDesktopShortcut(targetPath, executable, error)) {
+        return false;
+    }
+
+    if (menu && !createMenuShortcut(targetPath, executable, error)) {
+        return false;
+    }
+
+    return true;
+}
+
+bool InstallerLogic::createDesktopShortcut(const QString &targetPath, const QString &executable, QString &error) const {
+    Q_UNUSED(targetPath)
+#ifdef Q_OS_WIN
+    const QString desktopDir = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+    if (desktopDir.isEmpty()) {
+        error = tr("Não foi possível localizar a pasta da área de trabalho.");
+        return false;
+    }
+    const QString shortcutPath = QDir(desktopDir).filePath(QStringLiteral("AnythingLLM.lnk"));
+
+    QTemporaryFile scriptFile;
+    scriptFile.setAutoRemove(true);
+    if (!scriptFile.open()) {
+        error = tr("Não foi possível criar script temporário para o atalho.");
+        return false;
+    }
+
+    const QString script = QString::fromLatin1(
+        "$ErrorActionPreference='Stop';"
+        "$WScriptShell=New-Object -ComObject WScript.Shell;"
+        "$Shortcut=$WScriptShell.CreateShortcut('%1');"
+        "$Shortcut.TargetPath='%2';"
+        "$Shortcut.WorkingDirectory='%3';"
+        "$Shortcut.IconLocation='%2';"
+        "$Shortcut.Save();")
+                               .arg(shortcutPath.replace('\\', "\\\\"))
+                               .arg(executable.replace('\\', "\\\\"))
+                               .arg(QFileInfo(executable).absolutePath().replace('\\', "\\\\"));
+
+    scriptFile.write(script.toUtf8());
+    scriptFile.close();
+
+    const int exitCode = QProcess::execute(QStringLiteral("powershell"),
+                                           {QStringLiteral("-NoProfile"),
+                                            QStringLiteral("-ExecutionPolicy"),
+                                            QStringLiteral("Bypass"),
+                                            QStringLiteral("-File"),
+                                            scriptFile.fileName()});
+    if (exitCode != 0) {
+        error = tr("Falha ao criar atalho na área de trabalho (código %1).").arg(exitCode);
+        return false;
+    }
+    return true;
+#elif defined(Q_OS_MACOS)
+    const QString desktopDir = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+    if (desktopDir.isEmpty()) {
+        error = tr("Não foi possível localizar a pasta da área de trabalho.");
+        return false;
+    }
+    const QString linkPath = QDir(desktopDir).filePath(QStringLiteral("AnythingLLM.app"));
+    QFile::remove(linkPath);
+    if (!QFile::link(executable, linkPath)) {
+        error = tr("Falha ao criar alias na área de trabalho.");
+        return false;
+    }
+    return true;
+#else
+    const QString desktopDir = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+    if (desktopDir.isEmpty()) {
+        error = tr("Não foi possível localizar a pasta da área de trabalho.");
+        return false;
+    }
+
+    QFile desktopEntry(QDir(desktopDir).filePath(QStringLiteral("anything-llm.desktop")));
+    if (!desktopEntry.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        error = tr("Falha ao criar atalho na área de trabalho.");
+        return false;
+    }
+
+    const QString content = QStringLiteral(
+        "[Desktop Entry]\n"
+        "Type=Application\n"
+        "Name=AnythingLLM\n"
+        "Exec=\"%1\"\n"
+        "Icon=%1\n"
+        "Terminal=false\n"
+        "Categories=Utility;Development;\n")
+                               .arg(executable);
+    desktopEntry.write(content.toUtf8());
+    desktopEntry.close();
+    desktopEntry.setPermissions(QFile::ExeUser | QFile::ExeGroup | QFile::ExeOther |
+                                QFile::ReadUser | QFile::ReadGroup | QFile::ReadOther |
+                                QFile::WriteUser);
+    return true;
+#endif
+}
+
+bool InstallerLogic::createMenuShortcut(const QString &targetPath, const QString &executable, QString &error) const {
+    Q_UNUSED(targetPath)
+#ifdef Q_OS_WIN
+    QString menuDir = QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);
+    if (menuDir.isEmpty()) {
+        error = tr("Não foi possível localizar o diretório do menu iniciar.");
+        return false;
+    }
+    const QString shortcutPath = QDir(menuDir).filePath(QStringLiteral("AnythingLLM.lnk"));
+
+    QTemporaryFile scriptFile;
+    scriptFile.setAutoRemove(true);
+    if (!scriptFile.open()) {
+        error = tr("Não foi possível criar script temporário para o atalho.");
+        return false;
+    }
+
+    const QString script = QString::fromLatin1(
+        "$ErrorActionPreference='Stop';"
+        "$WScriptShell=New-Object -ComObject WScript.Shell;"
+        "$Shortcut=$WScriptShell.CreateShortcut('%1');"
+        "$Shortcut.TargetPath='%2';"
+        "$Shortcut.WorkingDirectory='%3';"
+        "$Shortcut.IconLocation='%2';"
+        "$Shortcut.Save();")
+                               .arg(shortcutPath.replace('\\', "\\\\"))
+                               .arg(executable.replace('\\', "\\\\"))
+                               .arg(QFileInfo(executable).absolutePath().replace('\\', "\\\\"));
+
+    scriptFile.write(script.toUtf8());
+    scriptFile.close();
+
+    const int exitCode = QProcess::execute(QStringLiteral("powershell"),
+                                           {QStringLiteral("-NoProfile"),
+                                            QStringLiteral("-ExecutionPolicy"),
+                                            QStringLiteral("Bypass"),
+                                            QStringLiteral("-File"),
+                                            scriptFile.fileName()});
+    if (exitCode != 0) {
+        error = tr("Falha ao criar atalho no menu iniciar (código %1).").arg(exitCode);
+        return false;
+    }
+    return true;
+#elif defined(Q_OS_MACOS)
+    Q_UNUSED(executable)
+    Q_UNUSED(error)
+    // No macOS criamos apenas alias na pasta Applications se necessário
+    return true;
+#else
+    QString menuDir = QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation);
+    if (menuDir.isEmpty()) {
+        menuDir = QDir::home().filePath(QStringLiteral(".local/share/applications"));
+    }
+    QDir().mkpath(menuDir);
+
+    QFile menuEntry(QDir(menuDir).filePath(QStringLiteral("anything-llm.desktop")));
+    if (!menuEntry.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        error = tr("Falha ao criar lançador no menu de aplicativos.");
+        return false;
+    }
+
+    const QString content = QStringLiteral(
+        "[Desktop Entry]\n"
+        "Type=Application\n"
+        "Name=AnythingLLM\n"
+        "Exec=\"%1\"\n"
+        "Icon=%1\n"
+        "Terminal=false\n"
+        "Categories=Utility;Development;\n")
+                               .arg(executable);
+    menuEntry.write(content.toUtf8());
+    menuEntry.close();
+    menuEntry.setPermissions(QFile::ExeUser | QFile::ExeGroup | QFile::ExeOther |
+                             QFile::ReadUser | QFile::ReadGroup | QFile::ReadOther |
+                             QFile::WriteUser);
+    return true;
+#endif
+}

--- a/extras/qt-installer/src/installerlogic.h
+++ b/extras/qt-installer/src/installerlogic.h
@@ -1,0 +1,78 @@
+#ifndef INSTALLERLOGIC_H
+#define INSTALLERLOGIC_H
+
+#include <QObject>
+#include <QString>
+#include <QMetaType>
+
+class InstallerLogic : public QObject {
+    Q_OBJECT
+public:
+    explicit InstallerLogic(QObject *parent = nullptr);
+
+    enum class InstallAction {
+        FreshInstall,
+        UpdateExisting,
+        RepairExisting
+    };
+    Q_ENUM(InstallAction)
+
+    struct InstallationStatus {
+        bool installed = false;
+        bool updateAvailable = false;
+        bool repairAvailable = false;
+        QString installedVersion;
+        QString availableVersion;
+        QString installPath;
+        InstallAction recommendedAction = InstallAction::FreshInstall;
+    };
+
+    struct InstallResult {
+        bool success = false;
+        QString message;
+    };
+
+    void startDetection();
+    void startInstallation(const QString &targetPath,
+                           InstallAction action,
+                           bool createDesktopShortcut,
+                           bool createMenuShortcut);
+
+    QString defaultInstallPath() const;
+    QString availableVersion() const;
+
+signals:
+    void detectionFinished(const InstallerLogic::InstallationStatus &status);
+    void installationProgress(const QString &message);
+    void installationStep(int progressValue);
+    void installationFinished(const InstallerLogic::InstallResult &result);
+
+private:
+    InstallationStatus detectInstallation() const;
+    InstallResult performInstallation(const QString &targetPath,
+                                      InstallAction action,
+                                      bool createDesktopShortcut,
+                                      bool createMenuShortcut);
+
+    QString installerStateFilePath() const;
+    bool saveInstallerState(const QString &path) const;
+    QString payloadDirectory() const;
+    bool ensureTargetDirectory(const QString &path, QString &error, InstallAction action) const;
+    bool copyPayload(const QString &targetPath, QString &error);
+    bool copyDirectoryRecursively(const QString &source, const QString &destination, QString &error);
+    qint64 countPayloadFiles(const QString &source) const;
+    int compareVersions(const QString &left, const QString &right) const;
+    QString executablePathForShortcuts(const QString &installDir) const;
+    bool createShortcuts(const QString &targetPath, bool desktop, bool menu, QString &error) const;
+    bool createDesktopShortcut(const QString &targetPath, const QString &executable, QString &error) const;
+    bool createMenuShortcut(const QString &targetPath, const QString &executable, QString &error) const;
+
+    QString m_availableVersion;
+    qint64 m_totalFiles = 0;
+    qint64 m_copiedFiles = 0;
+};
+
+Q_DECLARE_METATYPE(InstallerLogic::InstallationStatus)
+Q_DECLARE_METATYPE(InstallerLogic::InstallResult)
+
+#endif // INSTALLERLOGIC_H

--- a/extras/qt-installer/src/installerwindow.cpp
+++ b/extras/qt-installer/src/installerwindow.cpp
@@ -1,0 +1,219 @@
+#include "installerwindow.h"
+
+#include <QCheckBox>
+#include <QCloseEvent>
+#include <QFileDialog>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QIcon>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QTextEdit>
+#include <QVBoxLayout>
+#include <QStringList>
+
+InstallerWindow::InstallerWindow(QWidget *parent)
+    : QMainWindow(parent),
+      m_logic(new InstallerLogic(this)) {
+    buildUi();
+
+    connect(m_logic, &InstallerLogic::detectionFinished, this, &InstallerWindow::handleDetectionFinished);
+    connect(m_logic, &InstallerLogic::installationProgress, this, &InstallerWindow::handleInstallationProgress);
+    connect(m_logic, &InstallerLogic::installationStep, this, &InstallerWindow::handleInstallationStep);
+    connect(m_logic, &InstallerLogic::installationFinished, this, &InstallerWindow::handleInstallationFinished);
+
+    triggerDetection();
+}
+
+void InstallerWindow::buildUi() {
+    setWindowTitle(tr("Instalador AnythingLLM"));
+    setWindowIcon(QIcon(QStringLiteral(":/icons/app-icon.png")));
+    resize(720, 560);
+
+    QWidget *centralWidget = new QWidget(this);
+    setCentralWidget(centralWidget);
+
+    auto *mainLayout = new QVBoxLayout(centralWidget);
+
+    m_statusLabel = new QLabel(tr("Verificando instalação existente..."), this);
+    m_statusLabel->setWordWrap(true);
+    mainLayout->addWidget(m_statusLabel);
+
+    auto *pathLayout = new QHBoxLayout();
+    auto *pathLabel = new QLabel(tr("Local de instalação:"), this);
+    m_pathEdit = new QLineEdit(this);
+    m_pathEdit->setPlaceholderText(tr("Selecione o diretório onde AnythingLLM será instalado"));
+    auto *browseButton = new QPushButton(tr("Selecionar..."), this);
+    connect(browseButton, &QPushButton::clicked, this, &InstallerWindow::browseForPath);
+    pathLayout->addWidget(pathLabel);
+    pathLayout->addWidget(m_pathEdit, 1);
+    pathLayout->addWidget(browseButton);
+    mainLayout->addLayout(pathLayout);
+
+    auto *shortcutsGroup = new QGroupBox(tr("Atalhos"), this);
+    auto *shortcutsLayout = new QVBoxLayout(shortcutsGroup);
+    m_desktopShortcutCheck = new QCheckBox(tr("Criar atalho na área de trabalho"), shortcutsGroup);
+    m_menuShortcutCheck = new QCheckBox(tr("Adicionar ao menu iniciar/aplicativos"), shortcutsGroup);
+    m_desktopShortcutCheck->setChecked(true);
+    m_menuShortcutCheck->setChecked(true);
+    shortcutsLayout->addWidget(m_desktopShortcutCheck);
+    shortcutsLayout->addWidget(m_menuShortcutCheck);
+    shortcutsGroup->setLayout(shortcutsLayout);
+    mainLayout->addWidget(shortcutsGroup);
+
+    m_progressBar = new QProgressBar(this);
+    m_progressBar->setRange(0, 100);
+    m_progressBar->setValue(0);
+    mainLayout->addWidget(m_progressBar);
+
+    m_logOutput = new QTextEdit(this);
+    m_logOutput->setReadOnly(true);
+    m_logOutput->setPlaceholderText(tr("Mensagens de instalação aparecerão aqui."));
+    mainLayout->addWidget(m_logOutput, 1);
+
+    auto *buttonsLayout = new QHBoxLayout();
+    buttonsLayout->addStretch();
+    m_recheckButton = new QPushButton(tr("Verificar novamente"), this);
+    connect(m_recheckButton, &QPushButton::clicked, this, &InstallerWindow::triggerDetection);
+    m_installButton = new QPushButton(tr("Instalar"), this);
+    connect(m_installButton, &QPushButton::clicked, this, &InstallerWindow::startInstallation);
+    buttonsLayout->addWidget(m_recheckButton);
+    buttonsLayout->addWidget(m_installButton);
+    mainLayout->addLayout(buttonsLayout);
+}
+
+void InstallerWindow::handleDetectionFinished(const InstallerLogic::InstallationStatus &status) {
+    m_currentStatus = status;
+    updateUiForStatus(status);
+    setUiEnabled(true);
+}
+
+void InstallerWindow::handleInstallationProgress(const QString &message) {
+    appendLogMessage(message);
+}
+
+void InstallerWindow::handleInstallationStep(int value) {
+    m_progressBar->setValue(value);
+}
+
+void InstallerWindow::handleInstallationFinished(const InstallerLogic::InstallResult &result) {
+    m_installationInProgress = false;
+    setUiEnabled(true);
+
+    if (result.success) {
+        appendLogMessage(result.message);
+        QMessageBox::information(this, tr("Instalação"), result.message);
+        triggerDetection();
+    } else {
+        appendLogMessage(result.message);
+        QMessageBox::critical(this, tr("Instalação"), result.message);
+    }
+}
+
+void InstallerWindow::startInstallation() {
+    if (m_installationInProgress) {
+        return;
+    }
+
+    const QString targetPath = m_pathEdit->text().trimmed();
+    if (targetPath.isEmpty()) {
+        QMessageBox::warning(this, tr("Instalação"), tr("Informe um local de instalação válido."));
+        return;
+    }
+
+    InstallerLogic::InstallAction action = m_currentStatus.recommendedAction;
+    if (m_currentStatus.installed && targetPath != m_currentStatus.installPath) {
+        action = InstallerLogic::InstallAction::FreshInstall;
+    }
+
+    m_installationInProgress = true;
+    setUiEnabled(false);
+    m_progressBar->setValue(0);
+    m_logOutput->clear();
+
+    appendLogMessage(tr("Iniciando processo de instalação..."));
+    m_logic->startInstallation(targetPath, action, m_desktopShortcutCheck->isChecked(), m_menuShortcutCheck->isChecked());
+}
+
+void InstallerWindow::browseForPath() {
+    const QString selectedDirectory = QFileDialog::getExistingDirectory(this,
+                                                                       tr("Selecione o diretório de instalação"),
+                                                                       m_pathEdit->text().isEmpty() ? m_logic->defaultInstallPath() : m_pathEdit->text());
+    if (!selectedDirectory.isEmpty()) {
+        m_pathEdit->setText(selectedDirectory);
+    }
+}
+
+void InstallerWindow::triggerDetection() {
+    setUiEnabled(false);
+    appendLogMessage(tr("Verificando estado da instalação..."));
+    m_logic->startDetection();
+}
+
+void InstallerWindow::setUiEnabled(bool enabled) {
+    const bool allowInteraction = enabled && !m_installationInProgress;
+    m_pathEdit->setEnabled(allowInteraction);
+    m_installButton->setEnabled(allowInteraction);
+    m_recheckButton->setEnabled(enabled);
+    m_desktopShortcutCheck->setEnabled(allowInteraction);
+    m_menuShortcutCheck->setEnabled(allowInteraction);
+}
+
+void InstallerWindow::updateUiForStatus(const InstallerLogic::InstallationStatus &status) {
+    QStringList infoLines;
+    infoLines << tr("Versão disponível: %1").arg(status.availableVersion);
+
+    if (status.installed) {
+        if (!status.installedVersion.isEmpty()) {
+            infoLines << tr("Versão instalada: %1").arg(status.installedVersion);
+        }
+        if (status.updateAvailable) {
+            infoLines << tr("Uma atualização está disponível.");
+        } else {
+            infoLines << tr("A instalação já está atualizada.");
+        }
+        if (status.repairAvailable) {
+            infoLines << tr("Você pode reparar a instalação atual.");
+        }
+    } else {
+        infoLines << tr("Nenhuma instalação anterior encontrada.");
+    }
+
+    m_statusLabel->setText(infoLines.join('\n'));
+    m_pathEdit->setText(status.installPath);
+
+    switch (status.recommendedAction) {
+    case InstallerLogic::InstallAction::FreshInstall:
+        m_installButton->setText(tr("Instalar"));
+        break;
+    case InstallerLogic::InstallAction::UpdateExisting:
+        m_installButton->setText(tr("Atualizar"));
+        break;
+    case InstallerLogic::InstallAction::RepairExisting:
+        m_installButton->setText(tr("Reparar"));
+        break;
+    }
+}
+
+void InstallerWindow::appendLogMessage(const QString &message) {
+    if (message.isEmpty()) {
+        return;
+    }
+    m_logOutput->append(message);
+}
+
+void InstallerWindow::closeEvent(QCloseEvent *event) {
+    if (m_installationInProgress) {
+        const auto response = QMessageBox::question(this,
+                                                    tr("Instalação em andamento"),
+                                                    tr("Uma instalação está em andamento. Deseja realmente sair?"));
+        if (response != QMessageBox::Yes) {
+            event->ignore();
+            return;
+        }
+    }
+    QMainWindow::closeEvent(event);
+}

--- a/extras/qt-installer/src/installerwindow.h
+++ b/extras/qt-installer/src/installerwindow.h
@@ -1,0 +1,52 @@
+#ifndef INSTALLERWINDOW_H
+#define INSTALLERWINDOW_H
+
+#include <QMainWindow>
+
+#include "installerlogic.h"
+
+class QLabel;
+class QLineEdit;
+class QPushButton;
+class QCheckBox;
+class QTextEdit;
+class QProgressBar;
+
+class InstallerWindow : public QMainWindow {
+    Q_OBJECT
+public:
+    explicit InstallerWindow(QWidget *parent = nullptr);
+
+protected:
+    void closeEvent(QCloseEvent *event) override;
+
+private slots:
+    void handleDetectionFinished(const InstallerLogic::InstallationStatus &status);
+    void handleInstallationProgress(const QString &message);
+    void handleInstallationStep(int value);
+    void handleInstallationFinished(const InstallerLogic::InstallResult &result);
+    void startInstallation();
+    void browseForPath();
+    void triggerDetection();
+
+private:
+    void buildUi();
+    void setUiEnabled(bool enabled);
+    void updateUiForStatus(const InstallerLogic::InstallationStatus &status);
+    void appendLogMessage(const QString &message);
+
+    InstallerLogic *m_logic = nullptr;
+    InstallerLogic::InstallationStatus m_currentStatus;
+    bool m_installationInProgress = false;
+
+    QLabel *m_statusLabel = nullptr;
+    QLineEdit *m_pathEdit = nullptr;
+    QPushButton *m_installButton = nullptr;
+    QPushButton *m_recheckButton = nullptr;
+    QCheckBox *m_desktopShortcutCheck = nullptr;
+    QCheckBox *m_menuShortcutCheck = nullptr;
+    QTextEdit *m_logOutput = nullptr;
+    QProgressBar *m_progressBar = nullptr;
+};
+
+#endif // INSTALLERWINDOW_H

--- a/extras/qt-installer/src/main.cpp
+++ b/extras/qt-installer/src/main.cpp
@@ -1,0 +1,15 @@
+#include <QApplication>
+
+#include "installerwindow.h"
+
+int main(int argc, char *argv[]) {
+    QApplication application(argc, argv);
+    QApplication::setApplicationName(QStringLiteral("AnythingLLM Installer"));
+    QApplication::setOrganizationName(QStringLiteral("Mintplex Labs"));
+    QApplication::setApplicationVersion(QStringLiteral(APP_VERSION));
+
+    InstallerWindow window;
+    window.show();
+
+    return application.exec();
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anything-llm",
-  "version": "1.8.5",
+  "version": "1.9.0",
   "description": "The best solution for turning private documents into a chat bot using off-the-shelf tools and commercially viable AI technologies.",
   "main": "index.js",
   "type": "module",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anything-llm-server",
-  "version": "1.8.5",
+  "version": "1.9.0",
   "description": "Server endpoints to process or create content for chatting",
   "main": "index.js",
   "author": "Timothy Carambat (Mintplex Labs)",


### PR DESCRIPTION
## Summary
- add a new Qt 6 installer application that detects existing installations, copies payload files, and creates shortcuts
- provide a Qt/CMake project, resources, and documentation for building and using the installer
- bump AnythingLLM, server, and collector package versions to 1.9.0 to reflect the new functionality

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d956a0dc8483328b955425d14ea68b