### PR TITLE
docs: document Qt installer workflow and bump version to 1.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,23 @@ Mintplex Labs & the community maintain a number of deployment methods, scripts, 
 
 [or set up a production AnythingLLM instance without Docker →](./BARE_METAL.md)
 
+### Desktop installer (Qt 6)
+
+Need a guided desktop experience? The repository now ships with a cross-platform Qt 6 installer under [`extras/qt-installer/`](./extras/qt-installer). It provides smart version detection, desktop/menu shortcuts, and keeps installation metadata in `installer-state.json` so future runs can repair or upgrade an existing setup.
+
+#### Building the installer
+
+1. Produce the application payload you want to distribute (for example by running the usual Docker or bare-metal build and copying the resulting bundle).
+2. Place the release artifacts inside `extras/qt-installer/payload/`, mirroring the final directory structure that should be installed on end-user machines.
+3. Configure and build the installer binary:
+
+   ```bash
+   cmake -S extras/qt-installer -B extras/qt-installer/build -DAPP_VERSION="$(node -p "require('./server/package.json').version")"
+   cmake --build extras/qt-installer/build --target anything-llm-installer
+   ```
+
+The resulting executable in `extras/qt-installer/build/` can be shipped directly to end users. See the [installer README](./extras/qt-installer/README.md) for deeper customization notes (shortcut handling per platform, payload validation, etc.).
+
 ## How to setup for development
 
 - `yarn setup` To fill in the required `.env` files you'll need in each of the application sections (from root of repo).
@@ -173,6 +190,8 @@ Mintplex Labs & the community maintain a number of deployment methods, scripts, 
 - `yarn dev:server` To boot the server locally (from root of repo).
 - `yarn dev:frontend` To boot the frontend locally (from root of repo).
 - `yarn dev:collector` To then run the document collector (from root of repo).
+
+If you are orienting yourself around the monorepo for the first time, start with the [Repository Analysis](./REPOSITORY_ANALYSIS.md) for a birds-eye overview of each package and supporting asset.
 
 [Learn about documents](./server/storage/documents/DOCUMENTS.md)
 

--- a/REPOSITORY_ANALYSIS.md
+++ b/REPOSITORY_ANALYSIS.md
@@ -3,6 +3,7 @@
 ## 1. Repository Structure
 - **Monorepo layout:** The project hosts a Vite + React `frontend`, an Express-based `server`, and a document processing `collector`, each managed through Yarn scripts in the root `package.json`. Docker, cloud deployment templates, and submodules for web embeds and browser extensions round out the top-level directories.
 - **Supporting assets:** Deployment guidance (`docker/`, `cloud-deployments/`, `BARE_METAL.md`), security and contribution guidelines, and localization assets underpin the core application components.
+- **Desktop distribution tooling:** `extras/qt-installer/` now ships a Qt 6 graphical installer with upgrade detection, cross-platform shortcut creation, and payload packaging instructions for distributing the desktop build.
 
 ## 2. Integration & Build Tooling
 - **Root orchestration:** Root scripts coordinate setup across packages (dependency installation, Prisma setup, environment file initialization) and provide linting, development, and production commands.

--- a/collector/package.json
+++ b/collector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anything-llm-document-collector",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Document collector server endpoints",
   "main": "index.js",
   "author": "Timothy Carambat (Mintplex Labs)",

--- a/extras/qt-installer/CMakeLists.txt
+++ b/extras/qt-installer/CMakeLists.txt
@@ -28,7 +28,7 @@ qt_add_executable(anything-llm-installer
 )
 
 if (NOT DEFINED APP_VERSION)
-    set(APP_VERSION "1.9.0")
+    set(APP_VERSION "1.9.1")
 endif()
 
 target_compile_definitions(anything-llm-installer PRIVATE APP_VERSION="${APP_VERSION}")

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anything-llm-server",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Server endpoints to process or create content for chatting",
   "main": "index.js",
   "author": "Timothy Carambat (Mintplex Labs)",


### PR DESCRIPTION
### Pull Request Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [x] 📝 docs

### Relevant Issues

n/a

### What is in this change?

- add a desktop installer section to the main README describing payload preparation and the Qt 6 build commands
- point new contributors to the repository analysis overview for quicker onboarding
- mention the Qt installer in the repository analysis document and bump package versions to 1.9.1 to reflect the documentation updates

### Additional Information

- synchronised the default installer version constant with the new 1.9.1 patch release

### Developer Validations

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [x] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally

------
https://chatgpt.com/codex/tasks/task_e_68d97030517083328dc17bafc20eba5c